### PR TITLE
Feat/locations: add domains locations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ PG_USER=postgres
 PG_PASSWORD=postgres
 PG_DATABASE=goth
 PG_SSLMODE=disable
+PG_TIMEZONE=Asia/Jakarta
 PG_POOL_MAX=10
 
 # Redis

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,7 +10,6 @@ linters:
     - errchkjson
     - errorlint
     - forbidigo
-    - forcetypeassert
     - gocritic
     - interfacebloat
     - intrange
@@ -22,7 +21,6 @@ linters:
     - nlreturn
     - nosprintfhostport
     - perfsprint
-    - prealloc
     - stylecheck
     - wsl
 

--- a/Makefile
+++ b/Makefile
@@ -41,9 +41,9 @@ generate.domains: ### domains=$DOMAIN (generate domains including sqlc.yaml)
 		@echo "    queries: \"./queries.sql\"" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
 		@echo "    gen:" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
 		@echo "      go:" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
-		@echo "        package: \"sqlc\"" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
+		@echo "        package: \"repository\"" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
 		@echo "        sql_package: \"pgx/v5\"" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
-		@echo "        out: \"./sqlc\"" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
+		@echo "        out: \"../../../../internal/domains/$(domains)/repository\"" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
 		@echo "        emit_json_tags: true" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
 		@echo "        emit_db_tags: true" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
 		@echo "        emit_methods_with_db_argument: true" >> $(DB_PATH)/domains/$(domains)/sqlc.yaml
@@ -149,6 +149,10 @@ migrate.force: ### force migration
 lint: ### check by golangci linter
 	$(LOCAL_BIN)/golangci-lint run
 .PHONY: linter-golangci
+
+lint.fix: ### fix by golangci linter
+	$(LOCAL_BIN)/golangci-lint run --fix
+.PHONY: lint.fix
 
 test: generate generate.mock ### run test
 	@if ! -d ./tmp ]; then \

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,7 @@ type (
 		Password string `env:"PG_PASSWORD"`
 		Dbname   string `env:"PG_DATABASE,required"`
 		SSLMode  string `env:"PG_SSLMODE,required"`
+		Timezone string `env:"PG_TIMEZONE,required"`
 	}
 
 	Redis struct {

--- a/database/postgres/domains/locations/queries.sql
+++ b/database/postgres/domains/locations/queries.sql
@@ -1,0 +1,25 @@
+-- name: CreateLocation :one
+INSERT INTO locations (name, latitude, longitude, description)
+VALUES ($1, $2, $3, $4) RETURNING *;
+
+-- name: GetLocationById :one
+SELECT * FROM locations WHERE id = $1 AND deleted_at IS NULL LIMIT 1;
+
+-- name: GetLocationsWithFilter :many
+SELECT * FROM locations
+WHERE deleted_at IS NULL
+  AND ($1::text = '' OR name ILIKE '%' || $1 || '%')
+ORDER BY created_at DESC
+    LIMIT $2 OFFSET $3;
+
+-- name: CountLocationsWithFilter :one
+SELECT COUNT(*) FROM locations
+WHERE deleted_at IS NULL
+  AND ($1::text = '' OR name ILIKE '%' || $1 || '%');
+
+-- name: UpdateLocation :one
+UPDATE locations SET name = $1, latitude = $2, longitude = $3, description = $4, updated_at = now()
+    WHERE id = $5 AND deleted_at IS NULL RETURNING *;
+
+-- name: DeleteLocation :one
+UPDATE locations SET deleted_at = now() WHERE id = $1 AND deleted_at IS NULL RETURNING *;

--- a/database/postgres/domains/locations/schema.sql
+++ b/database/postgres/domains/locations/schema.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS locations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL CHECK (latitude BETWEEN -90 AND 90),
+    longitude DOUBLE PRECISION NOT NULL CHECK (longitude BETWEEN -180 AND 180),
+    description TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT now(),
+    updated_at TIMESTAMP DEFAULT now(),
+    deleted_at TIMESTAMP DEFAULT NULL
+);

--- a/database/postgres/domains/locations/sqlc.yaml
+++ b/database/postgres/domains/locations/sqlc.yaml
@@ -1,0 +1,15 @@
+version: "2"
+sql:
+  - name: "locations"
+    engine: "postgresql"
+    schema: "./schema.sql"
+    queries: "./queries.sql"
+    gen:
+      go:
+        package: "repository"
+        sql_package: "pgx/v5"
+        out: "../../../../internal/domains/locations/repository"
+        emit_json_tags: true
+        emit_db_tags: true
+        emit_methods_with_db_argument: true
+        emit_interface: true

--- a/database/postgres/migrations/000002_locations_table.down.sql
+++ b/database/postgres/migrations/000002_locations_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS locations;

--- a/database/postgres/migrations/000002_locations_table.up.sql
+++ b/database/postgres/migrations/000002_locations_table.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS locations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(255) NOT NULL,
+    latitude DOUBLE PRECISION NOT NULL CHECK (latitude BETWEEN -90 AND 90),
+    longitude DOUBLE PRECISION NOT NULL CHECK (longitude BETWEEN -180 AND 180),
+    description TEXT DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT now(),
+    updated_at TIMESTAMP DEFAULT now(),
+    deleted_at TIMESTAMP DEFAULT NULL
+);
+
+CREATE UNIQUE INDEX idx_locations_name ON locations(name, latitude, longitude);
+CREATE INDEX idx_locations_deleted_at ON locations USING btree (deleted_at ASC NULLS LAST);
+
+COMMIT;

--- a/internal/delivery/http/middleware/auth.go
+++ b/internal/delivery/http/middleware/auth.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"github.com/savioruz/goth/pkg/constant"
 	"github.com/savioruz/goth/pkg/failure"
 	"strings"
 
@@ -33,9 +34,9 @@ func Jwt() fiber.Handler {
 		}
 
 		if claims != nil {
-			c.Locals("user_id", claims.ID)
-			c.Locals("email", claims.Email)
-			c.Locals("level", claims.Level)
+			c.Locals(constant.JwtFieldUser, claims.ID)
+			c.Locals(constant.JwtFieldEmail, claims.Email)
+			c.Locals(constant.JwtFieldLevel, claims.Level)
 		}
 
 		return c.Next()

--- a/internal/delivery/http/middleware/rbac.go
+++ b/internal/delivery/http/middleware/rbac.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/savioruz/goth/internal/delivery/http/response"
+	"github.com/savioruz/goth/pkg/constant"
+	"github.com/savioruz/goth/pkg/failure"
+)
+
+func CheckRole(allowedRoles ...string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		role, ok := c.Locals(constant.JwtFieldLevel).(string)
+		if !ok {
+			err := failure.Unauthorized("role information not found")
+
+			return response.WithError(c, err)
+		}
+
+		for _, allowedRole := range allowedRoles {
+			if role == allowedRole {
+				return c.Next()
+			}
+		}
+
+		err := failure.Forbidden("insufficient permissions")
+
+		return response.WithError(c, err)
+	}
+}
+
+// AdminOnly protects routes with JWT and Role check for admin role.
+func AdminOnly() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if err := Jwt()(c); err != nil {
+			return err
+		}
+
+		return CheckRole(constant.UserRoleAdmin)(c)
+	}
+}

--- a/internal/delivery/http/response/response.go
+++ b/internal/delivery/http/response/response.go
@@ -9,12 +9,25 @@ type Data[T any] struct {
 	Data T `json:"data,omitempty"`
 }
 
+type Message struct {
+	Message string `json:"message"`
+}
+
 type Error struct {
 	Error *string `json:"error,omitempty"`
 }
 
 func WithJSON(ctx *fiber.Ctx, code int, payload interface{}) error {
 	err := response(ctx, code, Data[any]{Data: payload})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WithMessage(ctx *fiber.Ctx, code int, message string) error {
+	err := response(ctx, code, Message{message})
 	if err != nil {
 		return err
 	}

--- a/internal/domains/locations/dto/request.go
+++ b/internal/domains/locations/dto/request.go
@@ -1,0 +1,15 @@
+package dto
+
+type CreateLocationRequest struct {
+	Name        string  `json:"name" validate:"required"`
+	Latitude    float64 `json:"latitude" validate:"required,latitude"`
+	Longitude   float64 `json:"longitude" validate:"required,longitude"`
+	Description string  `json:"description" validate:"omitempty"`
+}
+
+type UpdateLocationRequest struct {
+	Name        string  `json:"name" validate:"omitempty"`
+	Latitude    float64 `json:"latitude" validate:"omitempty,latitude"`
+	Longitude   float64 `json:"longitude" validate:"omitempty,longitude"`
+	Description string  `json:"description" validate:"omitempty"`
+}

--- a/internal/domains/locations/dto/response.go
+++ b/internal/domains/locations/dto/response.go
@@ -47,6 +47,6 @@ func (l *PaginatedLocationResponse) FromModel(locations []repository.Location, t
 	l.Locations = make([]LocationResponse, len(locations))
 
 	for i, location := range locations {
-		l.Locations[i].FromModel(location)
+		l.Locations[i] = LocationResponse{}.FromModel(location)
 	}
 }

--- a/internal/domains/locations/dto/response.go
+++ b/internal/domains/locations/dto/response.go
@@ -1,0 +1,52 @@
+package dto
+
+import (
+	"github.com/savioruz/goth/internal/domains/locations/repository"
+	"github.com/savioruz/goth/pkg/constant"
+	"github.com/savioruz/goth/pkg/helper"
+)
+
+type LocationResponse struct {
+	ID          string  `json:"id"`
+	Name        string  `json:"name"`
+	Latitude    float64 `json:"latitude"`
+	Longitude   float64 `json:"longitude"`
+	Description string  `json:"description,omitempty"`
+	CreatedAt   string  `json:"created_at"`
+	UpdatedAt   string  `json:"updated_at"`
+}
+
+func (l LocationResponse) FromModel(model repository.Location) LocationResponse {
+	return LocationResponse{
+		ID:          model.ID.String(),
+		Name:        model.Name,
+		Latitude:    model.Latitude,
+		Longitude:   model.Longitude,
+		Description: model.Description.String,
+		CreatedAt:   model.CreatedAt.Time.Format(constant.DateFormat),
+		UpdatedAt:   model.UpdatedAt.Time.Format(constant.DateFormat),
+	}
+}
+
+type PaginatedLocationResponse struct {
+	Locations  []LocationResponse `json:"locations"`
+	TotalItems int                `json:"total_items"`
+	TotalPages int                `json:"total_pages"`
+}
+
+func (l *PaginatedLocationResponse) FromModel(locations []repository.Location, totalItems, limit int) {
+	l.TotalItems = totalItems
+	l.TotalPages = helper.CalculateTotalPages(totalItems, limit)
+
+	if len(locations) == 0 {
+		l.Locations = []LocationResponse{}
+
+		return
+	}
+
+	l.Locations = make([]LocationResponse, len(locations))
+
+	for i, location := range locations {
+		l.Locations[i].FromModel(location)
+	}
+}

--- a/internal/domains/locations/handler/handler.go
+++ b/internal/domains/locations/handler/handler.go
@@ -1,0 +1,260 @@
+package handler
+
+import (
+	"github.com/go-playground/validator/v10"
+	"github.com/gofiber/fiber/v2"
+	"github.com/savioruz/goth/internal/delivery/http/middleware"
+	"github.com/savioruz/goth/internal/delivery/http/response"
+	"github.com/savioruz/goth/internal/domains/locations/dto"
+	"github.com/savioruz/goth/internal/domains/locations/service"
+	"github.com/savioruz/goth/pkg/failure"
+	"github.com/savioruz/goth/pkg/gdto"
+	"github.com/savioruz/goth/pkg/logger"
+)
+
+type Handler struct {
+	service   service.LocationService
+	logger    logger.Interface
+	validator *validator.Validate
+}
+
+func New(s service.LocationService, l logger.Interface, v *validator.Validate) *Handler {
+	return &Handler{
+		service:   s,
+		logger:    l,
+		validator: v,
+	}
+}
+
+const (
+	identifier = "http - location - %s"
+)
+
+func (h *Handler) RegisterRoutes(r fiber.Router) {
+	location := r.Group("/locations")
+
+	location.Post("/", middleware.AdminOnly(), h.Create)
+	location.Get("/:id", h.Get)
+	location.Get("/", h.GetAll)
+	location.Patch("/:id", middleware.AdminOnly(), h.Update)
+	location.Delete("/:id", middleware.AdminOnly(), h.Delete)
+}
+
+// Create Location godoc
+// @Summary Create new location
+// @Description Create new location
+// @Tags locations
+// @Accept json
+// @Produce json
+// @Param location body dto.CreateLocationRequest true "Location create request"
+// @Success 201 {object} response.Data[string]
+// @Failure 400 {object} response.Error
+// @Failure 500 {object} response.Error
+// @Router /locations/ [post]
+// @Security BearerAuth
+func (h *Handler) Create(ctx *fiber.Ctx) error {
+	var req dto.CreateLocationRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		err = failure.BadRequestFromString(err.Error())
+
+		h.logger.Error(identifier, "create - body parsing error: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	if err := h.validator.Struct(req); err != nil {
+		err = failure.BadRequestFromString(err.Error())
+
+		h.logger.Error(identifier, "create - validate error: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	res, err := h.service.Create(ctx.UserContext(), req)
+	if err != nil {
+		h.logger.Error(identifier, "create - failed to create location: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	return response.WithMessage(ctx, fiber.StatusCreated, res)
+}
+
+// Get Location godoc
+// @Summary Get location by id
+// @Description Get location by id
+// @Tags locations
+// @Accept json
+// @Produce json
+// @Param id path string true "Location ID"
+// @Success 200 {object} response.Data[dto.LocationResponse]
+// @Failure 400 {object} response.Error
+// @Failure 500 {object} response.Error
+// @Router /locations/{id} [get]
+// @Security BearerAuth
+func (h *Handler) Get(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+	if id == "" {
+		err := failure.BadRequestFromString("location id is required")
+
+		h.logger.Error(identifier, "get - location id is required: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	if err := h.validator.Var(id, "required,uuid"); err != nil {
+		err = failure.BadRequestFromString("invalid location id format")
+
+		h.logger.Error(identifier, "get - invalid location id format: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	res, err := h.service.Get(ctx.UserContext(), id)
+	if err != nil {
+		h.logger.Error(identifier, "get - failed to get location: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	return response.WithJSON(ctx, fiber.StatusOK, res)
+}
+
+// GetAll Locations godoc
+// @Summary Get all locations
+// @Description Get all locations
+// @Tags locations
+// @Accept json
+// @Produce json
+// @Param request query gdto.PaginationRequest false "Pagination request"
+// @Success 200 {object} response.Data[dto.PaginatedLocationResponse[dto.LocationResponse]]
+// @Failure 400 {object} response.Error
+// @Failure 500 {object} response.Error
+// @Router /locations/ [get]
+// @Security BearerAuth
+func (h *Handler) GetAll(ctx *fiber.Ctx) error {
+	var req gdto.PaginationRequest
+	if err := ctx.QueryParser(&req); err != nil {
+		err = failure.BadRequestFromString(err.Error())
+
+		h.logger.Error(identifier, "get all - query parsing error: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	if err := h.validator.Struct(req); err != nil {
+		err = failure.BadRequestFromString(err.Error())
+
+		h.logger.Error(identifier, "get all - validate error: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	res, err := h.service.GetAll(ctx.UserContext(), req)
+	if err != nil {
+		h.logger.Error(identifier, "get all - failed to get locations: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	return response.WithJSON(ctx, fiber.StatusOK, res)
+}
+
+// Update Location godoc
+// @Summary Update location by id
+// @Description Update location by id
+// @Tags locations
+// @Accept json
+// @Produce json
+// @Param id path string true "Location ID"
+// @Param location body dto.UpdateLocationRequest true "Location update request"
+// @Success 200 {object} response.Data[string]
+// @Failure 400 {object} response.Error
+// @Failure 500 {object} response.Error
+// @Router /locations/{id} [patch]
+// @Security BearerAuth
+func (h *Handler) Update(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+	if id == "" {
+		err := failure.BadRequestFromString("location id is required")
+
+		h.logger.Error(identifier, "update - location id is required: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	if err := h.validator.Var(id, "required,uuid"); err != nil {
+		err = failure.BadRequestFromString("invalid location id format")
+
+		h.logger.Error(identifier, "update - invalid location id format: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	var req dto.UpdateLocationRequest
+	if err := ctx.BodyParser(&req); err != nil {
+		err = failure.BadRequestFromString(err.Error())
+
+		h.logger.Error(identifier, "update - body parsing error: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	if err := h.validator.Struct(req); err != nil {
+		err = failure.BadRequestFromString(err.Error())
+
+		h.logger.Error(identifier, "update - validate error: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	res, err := h.service.Update(ctx.UserContext(), id, req)
+	if err != nil {
+		h.logger.Error(identifier, "update - failed to update location: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	return response.WithMessage(ctx, fiber.StatusOK, res)
+}
+
+// Delete Location godoc
+// @Summary Delete location by id
+// @Description Delete location by id
+// @Tags locations
+// @Accept json
+// @Produce json
+// @Param id path string true "Location ID"
+// @Success 200 {object} response.Data[string]
+// @Failure 400 {object} response.Error
+// @Failure 404 {object} response.Error
+// @Failure 500 {object} response.Error
+// @Router /locations/{id} [delete]
+// @Security BearerAuth
+func (h *Handler) Delete(ctx *fiber.Ctx) error {
+	id := ctx.Params("id")
+	if id == "" {
+		err := failure.BadRequestFromString("location id is required")
+
+		h.logger.Error(identifier, "delete - location id is required: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	if err := h.validator.Var(id, "required,uuid"); err != nil {
+		err = failure.BadRequestFromString("invalid location id format")
+
+		h.logger.Error(identifier, "delete - invalid location id format: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	res, err := h.service.Delete(ctx.UserContext(), id)
+	if err != nil {
+		h.logger.Error(identifier, "delete - failed to delete location: %w", err)
+
+		return response.WithError(ctx, err)
+	}
+
+	return response.WithMessage(ctx, fiber.StatusOK, res)
+}

--- a/internal/domains/locations/service/service.go
+++ b/internal/domains/locations/service/service.go
@@ -1,0 +1,311 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/jackc/pgx/v5"
+	"github.com/savioruz/goth/config"
+	"github.com/savioruz/goth/internal/domains/locations/dto"
+	"github.com/savioruz/goth/internal/domains/locations/repository"
+	"github.com/savioruz/goth/pkg/failure"
+	"github.com/savioruz/goth/pkg/gdto"
+	"github.com/savioruz/goth/pkg/helper"
+	"github.com/savioruz/goth/pkg/logger"
+	"github.com/savioruz/goth/pkg/postgres"
+	"github.com/savioruz/goth/pkg/redis"
+	"reflect"
+	"strconv"
+)
+
+type LocationService interface {
+	Create(ctx context.Context, req dto.CreateLocationRequest) (res string, err error)
+	Get(ctx context.Context, id string) (res dto.LocationResponse, err error)
+	Count(ctx context.Context, filter string) (res int, err error)
+	GetAll(ctx context.Context, req gdto.PaginationRequest) (res dto.PaginatedLocationResponse, err error)
+	Update(ctx context.Context, id string, req dto.UpdateLocationRequest) (res string, err error)
+	Delete(ctx context.Context, id string) (res string, err error)
+}
+
+type locationService struct {
+	db     postgres.PgxIface
+	repo   repository.Querier
+	cache  redis.IRedisCache
+	cfg    *config.Config
+	logger logger.Interface
+}
+
+func New(db postgres.PgxIface, repo repository.Querier, cache redis.IRedisCache, cfg *config.Config, l logger.Interface) LocationService {
+	return &locationService{
+		db:     db,
+		repo:   repo,
+		cache:  cache,
+		cfg:    cfg,
+		logger: l,
+	}
+}
+
+const (
+	cacheGetLocationsKey = "locations"
+	cacheGetLocationKey  = "location"
+
+	identifier = "service - location - %s"
+)
+
+func (s *locationService) Create(ctx context.Context, req dto.CreateLocationRequest) (res string, err error) {
+	newLocation, err := s.repo.CreateLocation(ctx, s.db, repository.CreateLocationParams{
+		Name:        req.Name,
+		Latitude:    req.Latitude,
+		Longitude:   req.Longitude,
+		Description: helper.PgString(req.Description),
+	})
+	if err != nil {
+		s.logger.Error(identifier, "create - failed to create location: %w", err)
+
+		return res, err
+	}
+
+	res = newLocation.ID.String()
+
+	go func() {
+		ctx := context.WithoutCancel(ctx)
+
+		err := s.cache.Pipeline().
+			Delete(ctx, helper.BuildCacheKey(cacheGetLocationsKey, "count")).
+			Clear(ctx, helper.BuildCacheKey(cacheGetLocationsKey, "*")).
+			Exec(ctx)
+		if err != nil {
+			s.logger.Error(identifier, "create - failed clear cache: %w", err)
+		}
+	}()
+
+	return res, nil
+}
+
+func (s *locationService) Get(ctx context.Context, id string) (res dto.LocationResponse, err error) {
+	cacheKey := helper.BuildCacheKey(cacheGetLocationKey, id)
+
+	var cacheRes dto.LocationResponse
+	err = s.cache.Get(ctx, cacheKey, &cacheRes)
+
+	if err == nil {
+		s.logger.Info(identifier, "get - location %s - cache hit", id)
+
+		return cacheRes, nil
+	}
+
+	location, err := s.repo.GetLocationById(ctx, s.db, helper.PgUUID(id))
+	if errors.Is(err, pgx.ErrNoRows) {
+		s.logger.Info(identifier, "get - location %s - not found", id)
+
+		err := failure.NotFound(fmt.Sprintf("location %s - not found", id))
+
+		return res, err
+	}
+
+	if err != nil {
+		s.logger.Error(identifier, "get - failed to get location by id: %w", err)
+
+		return res, err
+	}
+
+	res = res.FromModel(location)
+
+	go func() {
+		err := s.cache.Save(context.WithoutCancel(ctx), cacheKey, res, s.cfg.Cache.Duration)
+		if err != nil {
+			s.logger.Error(identifier, "get - failed to set cache: %w", err)
+		}
+	}()
+
+	return res, nil
+}
+
+func (s *locationService) Count(ctx context.Context, filter string) (res int, err error) {
+	cacheKey := helper.BuildCacheKey(cacheGetLocationsKey, "count")
+
+	var cacheRes int
+	err = s.cache.Get(ctx, cacheKey, &cacheRes)
+
+	if err == nil {
+		s.logger.Info(identifier, "count - cache hit")
+
+		return cacheRes, nil
+	}
+
+	totalItems, err := s.repo.CountLocationsWithFilter(ctx, s.db, filter)
+	if err != nil {
+		s.logger.Error(identifier, "count - failed to count locations: %w", err)
+
+		return res, err
+	}
+
+	res = int(totalItems)
+
+	go func() {
+		err := s.cache.Save(context.WithoutCancel(ctx), cacheKey, res, s.cfg.Cache.Duration)
+		if err != nil {
+			s.logger.Error(identifier, "count - failed to set cache: %w", err)
+		}
+	}()
+
+	return res, nil
+}
+
+func (s *locationService) GetAll(ctx context.Context, req gdto.PaginationRequest) (res dto.PaginatedLocationResponse, err error) {
+	page, limit := helper.DefaultPagination(req.Page, req.Limit)
+
+	keyArgs := map[string]string{}
+	keyArgs["page"] = strconv.Itoa(page)
+	keyArgs["limit"] = strconv.Itoa(limit)
+	keyArgs["filter"] = req.Filter
+	cacheKey := helper.BuildCacheKey(cacheGetLocationsKey, helper.GenerateUniqueKey(keyArgs))
+
+	var cacheRes dto.PaginatedLocationResponse
+
+	err = s.cache.Get(ctx, cacheKey, &cacheRes)
+	if err == nil {
+		s.logger.Info(identifier, "get all - cache hit")
+
+		return cacheRes, nil
+	}
+
+	totalItems, err := s.Count(ctx, req.Filter)
+	if err != nil {
+		s.logger.Error(identifier, "get all - failed to count locations: %w", err)
+
+		return res, err
+	}
+
+	offset := helper.CalculateOffset(page, limit)
+
+	locations, err := s.repo.GetLocationsWithFilter(ctx, s.db, repository.GetLocationsWithFilterParams{
+		Column1: req.Filter,
+		Limit:   int32(limit),
+		Offset:  int32(offset),
+	})
+	if err != nil {
+		s.logger.Error(identifier, "get all - failed to get locations: %w", err)
+
+		return res, err
+	}
+
+	res.FromModel(locations, totalItems, limit)
+
+	go func() {
+		err := s.cache.Save(context.WithoutCancel(ctx), cacheKey, res, s.cfg.Cache.Duration)
+		if err != nil {
+			s.logger.Error(identifier, "get all - failed to set cache: %w", err)
+		}
+	}()
+
+	return res, nil
+}
+
+func (s *locationService) Update(ctx context.Context, id string, req dto.UpdateLocationRequest) (res string, err error) {
+	existingLocation, err := s.repo.GetLocationById(ctx, s.db, helper.PgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = failure.NotFound(fmt.Sprintf("location %s - not found", id))
+		}
+
+		s.logger.Error(identifier, "update - failed to get location by id: %w", err)
+
+		return res, err
+	}
+
+	val := reflect.ValueOf(req)
+	typ := reflect.TypeOf(req)
+
+	var updateFields []string
+
+	for i := range val.NumField() {
+		field := val.Field(i)
+		if field.IsZero() {
+			continue
+		}
+
+		fieldName := typ.Field(i).Tag.Get("json")
+		updateFields = append(updateFields, fieldName)
+
+		switch fieldName {
+		case "name":
+			existingLocation.Name = field.Interface().(string)
+		case "latitude":
+			existingLocation.Latitude = field.Interface().(float64)
+		case "longitude":
+			existingLocation.Longitude = field.Interface().(float64)
+		case "description":
+			existingLocation.Description = helper.PgString(field.Interface().(string))
+		}
+	}
+
+	if len(updateFields) == 0 {
+		s.logger.Error(identifier, "update - at least one field is required to update")
+
+		err := failure.BadRequestFromString("at least one field is required to update")
+
+		return res, err
+	}
+
+	newLocation, err := s.repo.UpdateLocation(ctx, s.db, repository.UpdateLocationParams{
+		ID:          helper.PgUUID(id),
+		Name:        existingLocation.Name,
+		Latitude:    existingLocation.Latitude,
+		Longitude:   existingLocation.Longitude,
+		Description: existingLocation.Description,
+	})
+
+	if err != nil {
+		s.logger.Error(identifier, "update - failed to update location: %w", err)
+
+		return res, err
+	}
+
+	res = newLocation.ID.String()
+
+	go func() {
+		ctx := context.WithoutCancel(ctx)
+
+		err := s.cache.Pipeline().
+			Delete(ctx, helper.BuildCacheKey(cacheGetLocationsKey, "count")).
+			Delete(ctx, helper.BuildCacheKey(cacheGetLocationKey, id)).
+			Clear(ctx, helper.BuildCacheKey(cacheGetLocationsKey, "*")).
+			Exec(ctx)
+		if err != nil {
+			s.logger.Error(identifier, "update - failed clear cache: %w", err)
+		}
+	}()
+
+	return res, nil
+}
+
+func (s *locationService) Delete(ctx context.Context, id string) (res string, err error) {
+	existingLocation, err := s.repo.DeleteLocation(ctx, s.db, helper.PgUUID(id))
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			err = failure.NotFound(fmt.Sprintf("location %s - not found", id))
+		}
+
+		s.logger.Error(identifier, "delete - failed to get location by id: %w", err)
+
+		return res, err
+	}
+
+	res = existingLocation.ID.String()
+
+	go func() {
+		ctx := context.WithoutCancel(ctx)
+
+		err := s.cache.Pipeline().
+			Delete(ctx, helper.BuildCacheKey(cacheGetLocationsKey, "count")).
+			Delete(ctx, helper.BuildCacheKey(cacheGetLocationKey, id)).
+			Clear(ctx, helper.BuildCacheKey(cacheGetLocationsKey, "*")).
+			Exec(ctx)
+		if err != nil {
+			s.logger.Error(identifier, "delete - failed clear cache: %w", err)
+		}
+	}()
+
+	return res, nil
+}

--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -1,0 +1,27 @@
+package constant
+
+import "time"
+
+const (
+	CacheParentKey = "mpti-backend"
+)
+
+const (
+	DateFormat = time.RFC3339
+)
+
+const (
+	UserRoleAdmin = "9"
+	UserRoleUser  = "1"
+)
+
+const (
+	JwtFieldUser  = "user_id"
+	JwtFieldEmail = "email"
+	JwtFieldLevel = "level"
+)
+
+const (
+	PaginationDefaultLimit = 10
+	PaginationDefaultPage  = 1
+)

--- a/pkg/gdto/dto.go
+++ b/pkg/gdto/dto.go
@@ -1,0 +1,7 @@
+package gdto
+
+type PaginationRequest struct {
+	Page   int    `json:"page" query:"page" validate:"omitempty,numeric,min=1"`
+	Limit  int    `json:"limit" query:"limit" validate:"omitempty,numeric,min=1,max=100"`
+	Filter string `json:"filter" query:"filter" validate:"omitempty,min=3"`
+}

--- a/pkg/postgres/builder.go
+++ b/pkg/postgres/builder.go
@@ -5,7 +5,7 @@ import (
 )
 
 func ConnectionBuilder(host string, port int, user, password, dbName, sslMode, timezone string) string {
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s TimeZone=%s",
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s timezone=%s",
 		host,
 		port,
 		user,

--- a/pkg/postgres/builder.go
+++ b/pkg/postgres/builder.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 )
 
-func ConnectionBuilder(host string, port int, user, password, dbName, sslMode string) string {
-	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
+func ConnectionBuilder(host string, port int, user, password, dbName, sslMode, timezone string) string {
+	dsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s TimeZone=%s",
 		host,
 		port,
 		user,
 		password,
 		dbName,
 		sslMode,
+		timezone,
 	)
 
 	return dsn


### PR DESCRIPTION
This pull request introduces significant changes to the codebase, focusing on adding a new "locations" domain, enhancing middleware functionality, and improving code organization. The most important changes include the creation of database schema and queries for the "locations" domain, the addition of middleware for role-based access control, and the implementation of HTTP handlers for managing locations.

### Additions to the "locations" domain:

* [`database/postgres/domains/locations/schema.sql`](diffhunk://#diff-5c4d95ab8e758d1d3522eab9babb5c1d8058421b322c0a3c1421f3a1575330daR1-R10): Added a schema for the "locations" table, including fields for `name`, `latitude`, `longitude`, and timestamps, with constraints on latitude and longitude values.
* [`database/postgres/domains/locations/queries.sql`](diffhunk://#diff-2c231b70cba25b1877e6360229e17a9f2644c69eadbddece799c1f544e969467R1-R25): Introduced SQL queries for CRUD operations on the "locations" table, including filtering and pagination support.
* [`internal/domains/locations/dto/request.go`](diffhunk://#diff-b7de52808d27eb53dc3957c0100789e01f56651d1384c5d70756bd145e5a9497R1-R15): Added DTOs for `CreateLocationRequest` and `UpdateLocationRequest` to validate incoming requests for creating and updating locations.
* [`internal/domains/locations/dto/response.go`](diffhunk://#diff-b8bc0aa886996d93a51274857270d124ec1e3881eb8e602fa9ca6ce54d8e0bb7R1-R52): Added DTOs for `LocationResponse` and `PaginatedLocationResponse` to structure responses for location-related endpoints.
* [`internal/domains/locations/handler/handler.go`](diffhunk://#diff-1ee4f01b44c1127907f6b2d5bb36cff7108a3ad8b72b09f6e4a6a1382c5519c3R1-R260): Implemented HTTP handlers for creating, retrieving, updating, and deleting locations, with route registration and validation logic.

### Middleware improvements:

* [`internal/delivery/http/middleware/rbac.go`](diffhunk://#diff-af3f6cde2dba46d5f52c2305c368c52ad2e404ea2a53e00110b1835adb17451aR1-R40): Added a new middleware for role-based access control (`CheckRole`) and an `AdminOnly` middleware to protect routes requiring admin privileges.
* [`internal/delivery/http/middleware/auth.go`](diffhunk://#diff-e26df067a976cad631a19ec7b6b6542263f20590866f6a0e1487d691924172deL36-R39): Refactored JWT middleware to use constants for local context keys, improving code maintainability.

### Database migrations:

* [`database/postgres/migrations/000002_locations_table.up.sql`](diffhunk://#diff-b7dfbff14d629aad08c1f9b74e33541272efe5acb46ba7882b3d6b2f16c9a04bR1-R17): Added a migration to create the "locations" table with constraints, unique index on `name`, `latitude`, and `longitude,` and an index on `deleted_at`.
* [`database/postgres/migrations/000002_locations_table.down.sql`](diffhunk://#diff-3b4b66c444d8c6bf782fbbd6ec8738c380aa23d1de490c6c5ec408d56bc76cd3R1): Added a rollback migration to drop the "locations" table.

### Configuration updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR18): Added `PG_TIMEZONE` configuration for database timezone settings.
* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R46): Updated the `Postgres` struct to include a `Timezone` field.

### Code organization and linting:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L44-R46): Updated the `generate.domains` task to output files to a new `repository` directory and added a `lint.fix` task for automatic linting fixes. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L44-R46) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R153-R156)
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L13): Removed `forcetypeassert` and `prealloc` linters from the configuration. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L13) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L25)