### PR TITLE
Chore/docs: remove auth on get fields and get locations

### DIFF
--- a/internal/domains/auth/service/service.go
+++ b/internal/domains/auth/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"github.com/savioruz/goth/pkg/constant"
 	"github.com/savioruz/goth/pkg/failure"
 	"github.com/savioruz/goth/pkg/logger"
 	"github.com/savioruz/goth/pkg/postgres"
@@ -74,7 +75,7 @@ func (s *authService) Register(ctx context.Context, req dto.UserRegisterRequest)
 			String: string(password),
 			Valid:  true,
 		},
-		Level: "1",
+		Level: constant.UserRoleUser,
 		FullName: pgtype.Text{
 			String: req.Name,
 			Valid:  true,

--- a/internal/domains/fields/handler/handler.go
+++ b/internal/domains/fields/handler/handler.go
@@ -98,7 +98,6 @@ func (h *Handler) Create(ctx *fiber.Ctx) error {
 // @Failure 404 {object} response.Error
 // @Failure 500 {object} response.Error
 // @Router /fields/{id} [get]
-// @Security BearerAuth
 func (h *Handler) Get(ctx *fiber.Ctx) error {
 	id := ctx.Params("id")
 	if id == "" {
@@ -133,7 +132,6 @@ func (h *Handler) Get(ctx *fiber.Ctx) error {
 // @Failure 400 {object} response.Error
 // @Failure 500 {object} response.Error
 // @Router /fields/ [get]
-// @Security BearerAuth
 func (h *Handler) GetAll(ctx *fiber.Ctx) error {
 	var req gdto.PaginationRequest
 	if err := ctx.QueryParser(&req); err != nil {
@@ -264,7 +262,6 @@ func (h *Handler) Delete(ctx *fiber.Ctx) error {
 // @Failure 404 {object} response.Error
 // @Failure 500 {object} response.Error
 // @Router /locations/{location_id}/fields [get]
-// @Security BearerAuth
 func (h *Handler) GetByLocationID(ctx *fiber.Ctx) error {
 	locationID := ctx.Params("location_id")
 	if err := h.validator.Var(locationID, "required,uuid"); err != nil {

--- a/internal/domains/locations/handler/handler.go
+++ b/internal/domains/locations/handler/handler.go
@@ -91,7 +91,6 @@ func (h *Handler) Create(ctx *fiber.Ctx) error {
 // @Failure 400 {object} response.Error
 // @Failure 500 {object} response.Error
 // @Router /locations/{id} [get]
-// @Security BearerAuth
 func (h *Handler) Get(ctx *fiber.Ctx) error {
 	id := ctx.Params("id")
 	if id == "" {
@@ -131,7 +130,6 @@ func (h *Handler) Get(ctx *fiber.Ctx) error {
 // @Failure 400 {object} response.Error
 // @Failure 500 {object} response.Error
 // @Router /locations/ [get]
-// @Security BearerAuth
 func (h *Handler) GetAll(ctx *fiber.Ctx) error {
 	var req gdto.PaginationRequest
 	if err := ctx.QueryParser(&req); err != nil {


### PR DESCRIPTION
This pull request includes updates to the `auth` service and handler files for `fields` and `locations`. The changes primarily involve replacing hardcoded values with constants for better maintainability and removing `BearerAuth` security annotations from several handler methods.

### Updates to `auth` service:

* **Use of constants for user roles**: Replaced the hardcoded `"1"` user level with `constant.UserRoleUser` in the `Register` method to improve code clarity and maintainability. (`internal/domains/auth/service/service.go`, [internal/domains/auth/service/service.goL77-R78](diffhunk://#diff-49dd6ac32e53b83237580cc1d34a352ccbda544f10fc135cb1f296031337cae5L77-R78))
* **New import for constants**: Added the `constant` package import to support the use of `constant.UserRoleUser`. (`internal/domains/auth/service/service.go`, [internal/domains/auth/service/service.goR6](diffhunk://#diff-49dd6ac32e53b83237580cc1d34a352ccbda544f10fc135cb1f296031337cae5R6))

### Updates to handler files:

* **Removal of `BearerAuth` annotations**: Removed `BearerAuth` security annotations from multiple handler methods (`Get`, `GetAll`, `GetByLocationID`) in the `fields` and `locations` domains. This likely reflects a change in authentication strategy or documentation updates. 
  - `fields` handlers: `Get`, `GetAll`, `GetByLocationID` (`internal/domains/fields/handler/handler.go`, [[1]](diffhunk://#diff-9d2fcf05123841ccb274497485d1dcf6f63db3fe96fc8a4e3c30570a2006b2ccL101) [[2]](diffhunk://#diff-9d2fcf05123841ccb274497485d1dcf6f63db3fe96fc8a4e3c30570a2006b2ccL136) [[3]](diffhunk://#diff-9d2fcf05123841ccb274497485d1dcf6f63db3fe96fc8a4e3c30570a2006b2ccL267)
  - `locations` handlers: `Get`, `GetAll` (`internal/domains/locations/handler/handler.go`, [[1]](diffhunk://#diff-1ee4f01b44c1127907f6b2d5bb36cff7108a3ad8b72b09f6e4a6a1382c5519c3L94) [[2]](diffhunk://#diff-1ee4f01b44c1127907f6b2d5bb36cff7108a3ad8b72b09f6e4a6a1382c5519c3L134)